### PR TITLE
Fixed typos and minor incongruences in Julia for Pythonistas notebook

### DIFF
--- a/Julia_for_Pythonistas.ipynb
+++ b/Julia_for_Pythonistas.ipynb
@@ -2193,7 +2193,7 @@
         "     - They handle indentation and the first line feed like regular\n",
         "       triple quoted strings.\n",
         "     - You only need to escape triple quotes like \\\"\"\", and the\n",
-        "       backslash before quotes like \\\\\\\".\n",
+        "       backslash before quotes like \\\\\".\n",
         "   \"\"\"\n",
         "println(s)"
       ],
@@ -5440,7 +5440,7 @@
       },
       "source": [
         "## Multidimensional Arrays\n",
-        "Importantly, NumPy arrays can be multidimensional, just like NumPy arrays:"
+        "Importantly, Julia arrays can be multidimensional, just like NumPy arrays:"
       ]
     },
     {
@@ -6223,7 +6223,7 @@
       },
       "source": [
         "* `a ∉ b` is equivalent to `!(a in b)` (or `a not in b` in Python). You can type `∉` with `\\notin<tab>`\n",
-        "* `a ∈ b` is equivalent to `a in b`. You can type it with `\\notin<tab>`"
+        "* `a ∈ b` is equivalent to `a in b`. You can type it with `\\in<tab>`"
       ]
     },
     {
@@ -7888,7 +7888,7 @@
         "outputId": "c85d29ff-0fd9-44b9-de53-62d3831252bc"
       },
       "source": [
-        "for (i, s) in zip(10:13, [\"Ten\", \"Twelve\", \"Thirteen\"])\n",
+        "for (i, s) in zip(10:13, [\"Ten\", \"Eleven\", \"Twelve\"])\n",
         "    println(i, \": \", s)\n",
         "end"
       ],
@@ -7898,8 +7898,8 @@
           "output_type": "stream",
           "text": [
             "10: Ten\n",
-            "11: Twelve\n",
-            "12: Thirteen\n"
+            "11: Eleven\n",
+            "12: Twelve\n"
           ],
           "name": "stdout"
         }
@@ -10274,7 +10274,7 @@
         "end\n",
         "\n",
         "width(sq::Square_v2) = sq.length\n",
-        "width(sq::Square_v2) = sq.length"
+        "height(sq::Square_v2) = sq.length"
       ],
       "execution_count": 213,
       "outputs": [
@@ -10339,6 +10339,23 @@
           ],
           "name": "stdout"
         }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Int64 <: Signed <: Integer <: Real <: Number <: Any"
+          ],
+          "name": "stdout"
+        }
+      ],
+      "source": [
+        "Base.show_supertypes(Int64)"
       ]
     },
     {
@@ -12378,7 +12395,7 @@
         "outputId": "d5fe0622-25e4-4817-cae0-bb0f1399cc8a"
       },
       "source": [
-        "read(\"test.txt\", String)"
+        "s = read(\"test.txt\", String)"
       ],
       "execution_count": 260,
       "outputs": [
@@ -13025,34 +13042,6 @@
             "tags": []
           },
           "execution_count": 270
-        }
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "Be3ZNSthij3t",
-        "colab_type": "code",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        },
-        "outputId": "a5ecb9d9-3cdb-4244-89d9-709372359902"
-      },
-      "source": [
-        "dump(SystemError)"
-      ],
-      "execution_count": 271,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "SystemError <: Exception\n",
-            "  prefix::AbstractString\n",
-            "  errnum::Int32\n",
-            "  extrainfo::Any\n"
-          ],
-          "name": "stdout"
         }
       ]
     },


### PR DESCRIPTION
I just went through the Julia for Pythonistas notebook (really awesome work, congratulations!) and noticed some minor typos, so I thought that it was worth making a pull request to correct them!

Besides obvious typos I added a cell for showing the supertypes of `Int64` at `execution_count = 214` since above the code cell you mention:

>This pattern is used everywhere in Julia's standard libraries. For example, here are the supertypes of `Float64` and `Int64`:

but never actually show the `Int64` part. I also removed the `dump(SystemError)` cell at `execution_count = 271` since it seemed to be a debugging leftover occurring out of context.